### PR TITLE
サインイン・ログインのユーザビリティを向上させる #29

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -24,7 +24,7 @@ if (flutterVersionName == null) {
 
 android {
     namespace "com.example.muscle_training_app"
-    // compileSdkVersion flutter.compileSdkVersion
+    compileSdkVersion 31
     compileSdk 34
     ndkVersion flutter.ndkVersion
 
@@ -46,7 +46,7 @@ android {
         multiDexEnabled true
         applicationId "com.example.muscle_training_app"
         minSdkVersion 21
-        targetSdkVersion flutter.targetSdkVersion
+        targetSdkVersion 31
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
     }
@@ -66,4 +66,5 @@ flutter {
 
 dependencies {
     coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.2.2'
+    implementation 'com.android.support:multidex:1.0.3'
 }

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,4 +1,10 @@
 PODS:
+  - AppAuth (1.7.5):
+    - AppAuth/Core (= 1.7.5)
+    - AppAuth/ExternalUserAgent (= 1.7.5)
+  - AppAuth/Core (1.7.5)
+  - AppAuth/ExternalUserAgent (1.7.5):
+    - AppAuth/Core
   - audioplayers_darwin (0.0.1):
     - Flutter
   - cloud_firestore (4.13.2):
@@ -101,10 +107,20 @@ PODS:
     - Flutter
   - flutter_native_splash (0.0.1):
     - Flutter
+  - google_sign_in_ios (0.0.1):
+    - AppAuth (>= 1.7.4)
+    - Flutter
+    - FlutterMacOS
+    - GoogleSignIn (~> 7.1)
+    - GTMSessionFetcher (>= 3.4.0)
   - GoogleDataTransport (9.4.1):
     - GoogleUtilities/Environment (~> 7.7)
     - nanopb (< 2.30911.0, >= 2.30908.0)
     - PromisesObjC (< 3.0, >= 1.2)
+  - GoogleSignIn (7.1.0):
+    - AppAuth (< 2.0, >= 1.7.3)
+    - GTMAppAuth (< 5.0, >= 4.1.1)
+    - GTMSessionFetcher/Core (~> 3.3)
   - GoogleUtilities/AppDelegateSwizzler (7.13.0):
     - GoogleUtilities/Environment
     - GoogleUtilities/Logger
@@ -130,7 +146,14 @@ PODS:
   - GoogleUtilities/UserDefaults (7.13.0):
     - GoogleUtilities/Logger
     - GoogleUtilities/Privacy
+  - GTMAppAuth (4.1.1):
+    - AppAuth/Core (~> 1.7)
+    - GTMSessionFetcher/Core (< 4.0, >= 3.3)
+  - GTMSessionFetcher (3.4.1):
+    - GTMSessionFetcher/Full (= 3.4.1)
   - GTMSessionFetcher/Core (3.4.1)
+  - GTMSessionFetcher/Full (3.4.1):
+    - GTMSessionFetcher/Core
   - image_picker_ios (0.0.1):
     - Flutter
   - leveldb-library (1.22.5)
@@ -160,12 +183,14 @@ DEPENDENCIES:
   - flutter_local_notifications (from `.symlinks/plugins/flutter_local_notifications/ios`)
   - flutter_localization (from `.symlinks/plugins/flutter_localization/ios`)
   - flutter_native_splash (from `.symlinks/plugins/flutter_native_splash/ios`)
+  - google_sign_in_ios (from `.symlinks/plugins/google_sign_in_ios/darwin`)
   - image_picker_ios (from `.symlinks/plugins/image_picker_ios/ios`)
   - path_provider_foundation (from `.symlinks/plugins/path_provider_foundation/darwin`)
   - shared_preferences_foundation (from `.symlinks/plugins/shared_preferences_foundation/darwin`)
 
 SPEC REPOS:
   trunk:
+    - AppAuth
     - Firebase
     - FirebaseAppCheckInterop
     - FirebaseAuth
@@ -184,7 +209,9 @@ SPEC REPOS:
     - FirebaseSharedSwift
     - FirebaseStorage
     - GoogleDataTransport
+    - GoogleSignIn
     - GoogleUtilities
+    - GTMAppAuth
     - GTMSessionFetcher
     - leveldb-library
     - nanopb
@@ -215,6 +242,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/flutter_localization/ios"
   flutter_native_splash:
     :path: ".symlinks/plugins/flutter_native_splash/ios"
+  google_sign_in_ios:
+    :path: ".symlinks/plugins/google_sign_in_ios/darwin"
   image_picker_ios:
     :path: ".symlinks/plugins/image_picker_ios/ios"
   path_provider_foundation:
@@ -228,6 +257,7 @@ CHECKOUT OPTIONS:
     :tag: 10.22.0
 
 SPEC CHECKSUMS:
+  AppAuth: 501c04eda8a8d11f179dbe8637b7a91bb7e5d2fa
   audioplayers_darwin: 877d9a4d06331c5c374595e46e16453ac7eafa40
   cloud_firestore: feb09f94fa4454b8faa9bd4ced7cb34f3b0a487c
   Firebase: 797fd7297b7e1be954432743a0b3f90038e45a71
@@ -256,8 +286,11 @@ SPEC CHECKSUMS:
   flutter_local_notifications: 4cde75091f6327eb8517fa068a0a5950212d2086
   flutter_localization: f43b18844a2b3d2c71fd64f04ffd6b1e64dd54d4
   flutter_native_splash: 52501b97d1c0a5f898d687f1646226c1f93c56ef
+  google_sign_in_ios: 07375bfbf2620bc93a602c0e27160d6afc6ead38
   GoogleDataTransport: 6c09b596d841063d76d4288cc2d2f42cc36e1e2a
+  GoogleSignIn: d4281ab6cf21542b1cfaff85c191f230b399d2db
   GoogleUtilities: d053d902a8edaa9904e1bd00c37535385b8ed152
+  GTMAppAuth: f69bd07d68cd3b766125f7e072c45d7340dea0de
   GTMSessionFetcher: 8000756fc1c19d2e5697b90311f7832d2e33f6cd
   image_picker_ios: b545a5f16c0fa88e3ecbbce3ed4de45567a8ec18
   leveldb-library: e8eadf9008a61f9e1dde3978c086d2b6d9b9dc28

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -17,7 +17,7 @@
 		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
 		97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */; };
 		B79A47B9671947A42D9A2E67 /* Pods_RunnerTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1E2874AE013622D8F8D5160A /* Pods_RunnerTests.framework */; };
-		FA3A225B2B00E2C90051978B /* GoogleService-Info (1).plist in Resources */ = {isa = PBXBuildFile; fileRef = FA3A225A2B00E2C90051978B /* GoogleService-Info (1).plist */; };
+		FA3A225B2B00E2C90051978B /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = FA3A225A2B00E2C90051978B /* GoogleService-Info.plist */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -68,7 +68,7 @@
 		D955D0F836676342D6D213C0 /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
 		E6CF6EB0D375C63CD1749948 /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
 		EC21599D1C13A5260DB7F66C /* GoogleService-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; name = "GoogleService-Info.plist"; path = "Runner/GoogleService-Info.plist"; sourceTree = "<group>"; };
-		FA3A225A2B00E2C90051978B /* GoogleService-Info (1).plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info (1).plist"; sourceTree = "<group>"; };
+		FA3A225A2B00E2C90051978B /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -157,7 +157,7 @@
 		97C146F01CF9000F007C117D /* Runner */ = {
 			isa = PBXGroup;
 			children = (
-				FA3A225A2B00E2C90051978B /* GoogleService-Info (1).plist */,
+				FA3A225A2B00E2C90051978B /* GoogleService-Info.plist */,
 				97C146FA1CF9000F007C117D /* Main.storyboard */,
 				97C146FD1CF9000F007C117D /* Assets.xcassets */,
 				97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */,
@@ -204,6 +204,7 @@
 				3B06AD1E1E4923F5004D2608 /* Thin Binary */,
 				A6F072BE1F7178EC501160A8 /* [CP] Embed Pods Frameworks */,
 				CE290DEDC68B04844834A526 /* Frameworks */,
+				B1ED261DCBD038A940D26BD4 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -267,7 +268,7 @@
 			files = (
 				97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */,
 				3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */,
-				FA3A225B2B00E2C90051978B /* GoogleService-Info (1).plist in Resources */,
+				FA3A225B2B00E2C90051978B /* GoogleService-Info.plist in Resources */,
 				97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */,
 				97C146FC1CF9000F007C117D /* Main.storyboard in Resources */,
 				3572CFDFCA5392AC0BA4DF17 /* GoogleService-Info.plist in Resources */,
@@ -345,6 +346,23 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		B1ED261DCBD038A940D26BD4 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		B400A1114883AC745295B9B1 /* [CP] Check Pods Manifest.lock */ = {

--- a/ios/Runner/GoogleService-Info.plist
+++ b/ios/Runner/GoogleService-Info.plist
@@ -2,6 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CLIENT_ID</key>
+	<string>667012922671-7h4ql6rbs2er33o07c3hali5pl4146os.apps.googleusercontent.com</string>
+	<key>REVERSED_CLIENT_ID</key>
+	<string>com.googleusercontent.apps.667012922671-7h4ql6rbs2er33o07c3hali5pl4146os</string>
 	<key>API_KEY</key>
 	<string>AIzaSyCN0Kv-1FSg9coswhMCs1qBycdV312akoQ</string>
 	<key>GCM_SENDER_ID</key>

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -51,6 +51,20 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
+	<!-- Google Sign-in Section -->
+<key>CFBundleURLTypes</key>
+<array>
+	<dict>
+		<key>CFBundleTypeRole</key>
+		<string>Editor</string>
+		<key>CFBundleURLSchemes</key>
+		<array>
+			<!-- Copied from GoogleService-Info.plist key REVERSED_CLIENT_ID -->
+			<string>com.googleusercontent.apps.667012922671-7h4ql6rbs2er33o07c3hali5pl4146os</string>
+		</array>
+	</dict>
+</array>
+<!-- End of the Google Sign-in Section -->
 	<!-- image_pickerの設定 -->
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>Photo Library Usage</string>

--- a/lib/constant/colors.dart
+++ b/lib/constant/colors.dart
@@ -23,7 +23,11 @@ const noReactionColor = Color.fromRGBO(255, 0, 0, 1.0);
 
 // 色々
 const greyColor = Colors.grey;
-const addFloationActionButtonColor = Colors.lightBlueAccent;
+const addFloationActionButtonColor = Color.fromRGBO(0, 173, 169, 1);
+
+const lightGreenColor = Color.fromRGBO(82, 215, 170, 1);
+const mediumGreenColor = Color.fromRGBO(0, 185, 138, 1);
+const darkGreenColor = Color.fromRGBO(0, 128, 97, 1);
 
 // githubの草の色(ライトモード順)
 const trainingFrequencyColor1 = Color.fromRGBO(235, 237, 240, 1);

--- a/lib/constant/text_resorce.dart
+++ b/lib/constant/text_resorce.dart
@@ -31,9 +31,40 @@ const validationRes = '未入力の項目があります。';
 const successSignUp = '新規登録に成功しました！';
 const failureSignUp = '問題が発生しました。もう一度、新規登録をしてください。';
 
+// 新規登録時のバリデーション
+const please_enter_email = 'メースアドレスを入力してください';
+const please_enter_password = 'パスワードを入力してください';
+const wrong_password = 'パスワードが正しくありません';
+
 // ログイン
 const successLogin = 'ログインに成功しました！';
 const failureLogin = '問題が発生しました。もう一度、ログインしてください。';
+
+// パスワードを忘れた場合
+const forgot_your_password = 'パスワードを忘れましたか？';
+const user_not_found = 'user-not-found';
+const user_not_found_message = 'ユーザーが見つかりません';
+const successSendEmail = 'パスワード再設定手続きのためのメールを送信しました。';
+const successResendEmail = 'メールを再送信しました。メールボックスをご確認ください。';
+const successResetPassword = 'パスワードの変更が完了しました。';
+
+// Googleでサインアップ・ログイン
+const signInOnGoogle = 'Googleで新規登録';
+const loginOnGoogle = 'Googleでログイン';
+
+// FirebaseExceptionエラー
+const invalid_email = 'invalid-email';
+const invalid_email_message = 'メールアドレスが有効ではありません。';
+
+const email_already_in_use = 'email-already-in-use';
+const email_already_in_use_message = 'そのメールアドレスを持つアカウントは既に存在しています。';
+
+const operation_not_allowed = 'operation-not-allowed';
+const operation_not_allowed_message =
+    'アカウントが有効ではありません。Firebase コンソールの Auth タブで、メール/パスワード アカウントを有効にしてください。';
+
+const weak_password = 'weak-password';
+const weak_password_message = 'パスワードを強化してください。';
 
 // メモ関連
 const eventTx = '種目';

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -5,6 +5,7 @@ import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart' as riverpod;
 import 'package:intl/date_symbol_data_local.dart';
 import 'package:muscle_training_app/models/menu_model/menu_model.dart';
+import 'package:muscle_training_app/providers/auth_check_page.dart';
 import 'package:muscle_training_app/providers/user_provider.dart';
 import 'package:muscle_training_app/resposive/mobile_screen_layout.dart';
 import 'package:muscle_training_app/resposive/resposive_layout.dart';
@@ -23,8 +24,7 @@ void main() async {
     );
   } catch (e) {
     print('Firebase initialization failed: $e');
-    // Firebaseの初期化に失敗した場合のエラーハンドリング
-    // エラーメッセージを表示するなど、適切な処理を追加してください
+    // Firebaseの初期化に失敗した場合のエラーハンドリング追記予定
     return;
   }
 
@@ -67,31 +67,32 @@ class MyApp extends StatelessWidget {
           brightness: Brightness.light,
         ),
         darkTheme: ThemeData.dark(),
-        home: StreamBuilder<User?>(
-          stream: FirebaseAuth.instance.authStateChanges(),
-          builder: (context, snapshot) {
-            if (snapshot.connectionState == ConnectionState.active) {
-              if (snapshot.hasData) {
-                // User が null でなない、つまりサインイン済みのホーム画面へ
-                return const ResponsiveLayout(
-                  webScreenLayout: WebScreenLayout(),
-                  mobileScreenLayout: MobileScreenLayout(),
-                );
-              } else if (snapshot.hasError) {
-                return Center(
-                  child: Text('${snapshot.error}'),
-                );
-              } else {
-                // User がnullの場合、ログイン画面へ
-                return LoginPage();
-              }
-            }
-            if (snapshot.connectionState == ConnectionState.waiting) {
-              return const SizedBox();
-            }
-            return const LoginPage();
-          },
-        ),
+        // home: StreamBuilder<User?>(
+        //   stream: FirebaseAuth.instance.authStateChanges(),
+        //   builder: (context, snapshot) {
+        //     if (snapshot.connectionState == ConnectionState.active) {
+        //       if (snapshot.hasData) {
+        //         // User が null でなない、つまりサインイン済みのホーム画面へ
+        //         return const ResponsiveLayout(
+        //           webScreenLayout: WebScreenLayout(),
+        //           mobileScreenLayout: MobileScreenLayout(),
+        //         );
+        //       } else if (snapshot.hasError) {
+        //         return Center(
+        //           child: Text('${snapshot.error}'),
+        //         );
+        //       } else {
+        //         // User がnullの場合、ログイン画面へ
+        //         return LoginPage();
+        //       }
+        //     }
+        //     if (snapshot.connectionState == ConnectionState.waiting) {
+        //       return const SizedBox();
+        //     }
+        //     return const LoginPage();
+        //   },
+        // ),
+        home: AuthCheckPage(),
       ),
     );
   }

--- a/lib/main_navigation.dart
+++ b/lib/main_navigation.dart
@@ -9,8 +9,8 @@ final indexProvider = StateProvider((ref) {
   return 0;
 });
 
-class Myapp extends ConsumerWidget {
-  const Myapp({super.key});
+class MainNavigation extends ConsumerWidget {
+  const MainNavigation({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {

--- a/lib/main_navigation.dart
+++ b/lib/main_navigation.dart
@@ -3,9 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:muscle_training_app/constant/colors.dart';
 import 'package:muscle_training_app/constant/globalvariavle.dart';
 
-// プロバイダー
 final indexProvider = StateProvider((ref) {
-  // 変化させたいデータ
   return 0;
 });
 

--- a/lib/providers/auth_check_page.dart
+++ b/lib/providers/auth_check_page.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:muscle_training_app/constant/colors.dart';
+import 'package:muscle_training_app/providers/auth_state_notifier.dart';
+import 'package:muscle_training_app/resposive/mobile_screen_layout.dart';
+import 'package:muscle_training_app/resposive/resposive_layout.dart';
+import 'package:muscle_training_app/resposive/web_screen_layout.dart';
+import 'package:muscle_training_app/view/login/login_page.dart';
+
+class AuthCheckPage extends StatelessWidget {
+  const AuthCheckPage({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Center(
+        child: Consumer(
+          builder: (context, ref, child) {
+            final userAsyncValue = ref.watch(authStateNotifierProvider);
+            return userAsyncValue.when(
+              data: (user) {
+                if (user != null) {
+                  return ResponsiveLayout(
+                    webScreenLayout: WebScreenLayout(),
+                    mobileScreenLayout: MobileScreenLayout(),
+                  );
+                } else {
+                  return LoginPage();
+                }
+              },
+              loading: () => Center(
+                child: CircularProgressIndicator(
+                  color: linkBlue,
+                ),
+              ),
+              error: (error, stackTrace) => Text('Error: $error'),
+            );
+          },
+        ),
+      ),
+    );
+  }
+}

--- a/lib/providers/auth_state_notifier.dart
+++ b/lib/providers/auth_state_notifier.dart
@@ -1,0 +1,13 @@
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'auth_state_notifier.g.dart';
+
+@riverpod
+class AuthStateNotifier extends _$AuthStateNotifier {
+  @override
+  Stream<User?> build() {
+    // ユーザーの状態変更を監視
+    return FirebaseAuth.instance.authStateChanges();
+  }
+}

--- a/lib/providers/auth_state_notifier.g.dart
+++ b/lib/providers/auth_state_notifier.g.dart
@@ -1,0 +1,26 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'auth_state_notifier.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$authStateNotifierHash() => r'd01112a3e76231a631117bed36bd9e6e624ac7cc';
+
+/// See also [AuthStateNotifier].
+@ProviderFor(AuthStateNotifier)
+final authStateNotifierProvider =
+    AutoDisposeStreamNotifierProvider<AuthStateNotifier, User?>.internal(
+  AuthStateNotifier.new,
+  name: r'authStateNotifierProvider',
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$authStateNotifierHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+typedef _$AuthStateNotifier = AutoDisposeStreamNotifier<User?>;
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member

--- a/lib/resources/auth_methods.dart
+++ b/lib/resources/auth_methods.dart
@@ -166,4 +166,23 @@ class AuthMethods {
     }
     return res;
   }
+
+  Future<String> resetPasswordForm({required String targetEmail}) async {
+    String res = invalid_email_message;
+    try {
+      await FirebaseAuth.instance.sendPasswordResetEmail(email: targetEmail);
+      res = successRes;
+    } on FirebaseAuthException catch (e) {
+      if (e.code == invalid_email) {
+        res = invalid_email_message;
+      } else if (e.code == user_not_found) {
+        res = user_not_found_message;
+      } else {
+        res = e.toString();
+      }
+    } catch (err) {
+      res = err.toString();
+    }
+    return res;
+  }
 }

--- a/lib/resources/auth_methods.dart
+++ b/lib/resources/auth_methods.dart
@@ -1,5 +1,6 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
+import 'package:google_sign_in/google_sign_in.dart';
 import 'package:muscle_training_app/constant/text_resorce.dart';
 import 'package:muscle_training_app/domain/user.dart' as userModel;
 
@@ -53,18 +54,76 @@ class AuthMethods {
         res = validationRes;
       }
     } on FirebaseException catch (e) {
-      if (e.code == 'invalid-email') {
-        res = 'メールアドレスが有効で有効ではありません。';
+      if (e.code == invalid_email) {
+        res = invalid_email_message;
       }
-      if (e.code == 'email-already-in-use') {
-        res = 'そのメールアドレスを持つアカウントは既に存在しています。';
+      if (e.code == email_already_in_use) {
+        res = email_already_in_use_message;
       }
-      if (e.code == 'operation-not-allowed') {
-        res =
-            'アカウントが有効ではありません。Firebase コンソールの Auth タブで、メール/パスワード アカウントを有効にしてください。';
+      if (e.code == operation_not_allowed) {
+        res = operation_not_allowed_message;
       }
-      if (e.code == 'weak-password') {
-        res = 'パスワードを強化してください。';
+      if (e.code == weak_password) {
+        res = weak_password_message;
+      }
+    } catch (err) {
+      res = err.toString();
+    }
+    return res;
+  }
+
+  // Googleサインイン
+  Future<String> signInWithGoogleAccount() async {
+    String res = successLogin;
+    try {
+      final GoogleSignInAccount? googleUser = await GoogleSignIn().signIn();
+      final GoogleSignInAuthentication? googleAuth =
+          await googleUser?.authentication;
+
+      final credential = GoogleAuthProvider.credential(
+        accessToken: googleAuth?.accessToken,
+        idToken: googleAuth?.idToken,
+      );
+
+      UserCredential userCredential =
+          await _auth.signInWithCredential(credential);
+
+      User? userCred = userCredential.user;
+
+      if (userCred != null) {
+        if (userCredential.additionalUserInfo!.isNewUser) {
+          userModel.User user = userModel.User(
+            email: userCred.email!,
+            uid: userCred.uid,
+            username: 'unknown',
+            photoUrl: defaultPhotoUrlString,
+            shortTermGoals: '',
+            longTermGoals: '',
+            createAt: DateTime.now(),
+            lastLogin: DateTime.now(),
+            consecutiveLoginDays: 1,
+            followers: [],
+            following: [],
+          );
+
+          await _firestore.collection('users').doc(userCred.uid).set(
+                user.toJson(),
+              );
+        }
+        res = successRes;
+      }
+    } on FirebaseException catch (e) {
+      if (e.code == invalid_email) {
+        res = invalid_email_message;
+      }
+      if (e.code == email_already_in_use) {
+        res = email_already_in_use_message;
+      }
+      if (e.code == operation_not_allowed) {
+        res = operation_not_allowed_message;
+      }
+      if (e.code == weak_password) {
+        res = weak_password_message;
       }
     } catch (err) {
       res = err.toString();
@@ -90,18 +149,17 @@ class AuthMethods {
         res = validationRes;
       }
     } on FirebaseException catch (e) {
-      if (e.code == 'invalid-email') {
-        res = 'メールアドレスが有効で有効ではありません。';
+      if (e.code == invalid_email) {
+        res = invalid_email_message;
       }
-      if (e.code == 'email-already-in-use') {
-        res = 'そのメールアドレスを持つアカウントは既に存在しています。';
+      if (e.code == email_already_in_use) {
+        res = email_already_in_use_message;
       }
-      if (e.code == 'operation-not-allowed') {
-        res =
-            'アカウントが有効ではありません。Firebase コンソールの Auth タブで、メール/パスワード アカウントを有効にしてください。';
+      if (e.code == operation_not_allowed) {
+        res = operation_not_allowed_message;
       }
-      if (e.code == 'weak-password') {
-        res = 'パスワードを強化してください。';
+      if (e.code == weak_password) {
+        res = weak_password_message;
       }
     } catch (err) {
       res = err.toString();

--- a/lib/resposive/mobile_screen_layout.dart
+++ b/lib/resposive/mobile_screen_layout.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:muscle_training_app/myapp.dart';
+import 'package:muscle_training_app/main_navigation.dart';
 
 class MobileScreenLayout extends StatelessWidget {
   const MobileScreenLayout({super.key});
@@ -7,7 +7,7 @@ class MobileScreenLayout extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return const Scaffold(
-      body: Myapp(),
+      body: MainNavigation(),
     );
   }
 }

--- a/lib/view/calendar/add_event.dart
+++ b/lib/view/calendar/add_event.dart
@@ -5,7 +5,7 @@ import 'package:muscle_training_app/constant/text_resorce.dart';
 import 'package:muscle_training_app/domain/user.dart';
 import 'package:muscle_training_app/providers/user_provider.dart';
 import 'package:muscle_training_app/resources/calendar_firestore_methods.dart';
-import 'package:muscle_training_app/myapp.dart';
+import 'package:muscle_training_app/main_navigation.dart';
 import 'package:muscle_training_app/widgets/add_button.dart';
 import 'package:muscle_training_app/util/show_snackbar.dart';
 import 'package:provider/provider.dart';
@@ -185,7 +185,7 @@ class _AddEventState extends State<AddEventPage> {
                 await Navigator.pushAndRemoveUntil(
                   context,
                   MaterialPageRoute<void>(
-                    builder: (_) => const Myapp(),
+                    builder: (_) => const MainNavigation(),
                   ),
                   (_) => false,
                 );

--- a/lib/view/calendar/calendar_page.dart
+++ b/lib/view/calendar/calendar_page.dart
@@ -330,7 +330,6 @@ class _CalendarPageState extends State<CalendarPage> {
         ),
         child: const Icon(
           Icons.fitness_center,
-          color: mainColor,
         ),
       ),
     );

--- a/lib/view/calendar/calendar_page.dart
+++ b/lib/view/calendar/calendar_page.dart
@@ -11,7 +11,7 @@ import 'package:muscle_training_app/view/calendar/event_item.dart';
 import 'package:table_calendar/table_calendar.dart';
 
 import '../../domain/calendar.dart';
-import '../../myapp.dart';
+import '../../main_navigation.dart';
 import 'bottom_sheet.dart';
 
 class CalendarPage extends StatefulWidget {
@@ -302,7 +302,7 @@ class _CalendarPageState extends State<CalendarPage> {
                   await Navigator.pushAndRemoveUntil(
                     context,
                     MaterialPageRoute<void>(
-                      builder: (_) => const Myapp(),
+                      builder: (_) => const MainNavigation(),
                     ),
                     (_) => false,
                   );

--- a/lib/view/calendar/edit_event.dart
+++ b/lib/view/calendar/edit_event.dart
@@ -5,7 +5,7 @@ import 'package:flutter_colorpicker/flutter_colorpicker.dart';
 import 'package:muscle_training_app/constant/colors.dart';
 import 'package:muscle_training_app/domain/calendar.dart';
 
-import '../../myapp.dart';
+import '../../main_navigation.dart';
 
 class EditEventPage extends StatefulWidget {
   const EditEventPage({
@@ -189,7 +189,7 @@ class _EditEventState extends State<EditEventPage> {
       await Navigator.pushAndRemoveUntil(
         context,
         MaterialPageRoute<void>(
-          builder: (_) => const Myapp(),
+          builder: (_) => const MainNavigation(),
         ),
         (_) => false,
       );

--- a/lib/view/login/email_confirmation_page.dart
+++ b/lib/view/login/email_confirmation_page.dart
@@ -1,0 +1,225 @@
+import 'package:muscle_training_app/constant/colors.dart';
+import 'package:muscle_training_app/constant/text_resorce.dart';
+import 'package:muscle_training_app/providers/user_provider.dart';
+import 'package:muscle_training_app/resources/auth_methods.dart';
+import 'package:muscle_training_app/util/show_snackbar.dart';
+import 'package:muscle_training_app/view/login/login_page.dart';
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+class EmailConfirmationPage extends StatefulWidget {
+  const EmailConfirmationPage({
+    super.key,
+    required this.targetEmail,
+  });
+  final String targetEmail;
+
+  @override
+  _EmailConfirmationPageState createState() => _EmailConfirmationPageState();
+}
+
+class _EmailConfirmationPageState extends State<EmailConfirmationPage> {
+  @override
+  Widget build(BuildContext context) {
+    final userProvider = Provider.of<UserProvider>(context);
+
+    void navigatorToLogin() {
+      Navigator.of(context).pushReplacement(
+        MaterialPageRoute(
+          builder: (context) => const LoginPage(),
+        ),
+      );
+    }
+
+    Future<void> resetPasswordForm(
+      BuildContext context,
+      UserProvider userProvider,
+    ) async {
+      userProvider.startLoading();
+      String res = await AuthMethods().resetPasswordForm(
+        targetEmail: widget.targetEmail,
+      );
+
+      if (res == successRes) {
+        res = successResendEmail;
+        userProvider.endLoading();
+        showSnackBar(res, context);
+      } else {
+        showSnackBar(res, context);
+      }
+      userProvider.endLoading();
+    }
+
+    return Scaffold(
+      backgroundColor: secondaryColor,
+      body: SafeArea(
+        child: Container(
+          padding: const EdgeInsets.symmetric(
+            horizontal: 32,
+          ),
+          width: double.infinity,
+          child: Column(
+            children: [
+              Flexible(
+                flex: 1,
+                child: Container(),
+              ),
+              Stack(
+                children: [
+                  Container(
+                    height: 160,
+                    width: 160,
+                    decoration: BoxDecoration(
+                      color: lightGreenColor,
+                      shape: BoxShape.circle,
+                    ),
+                  ),
+                  Positioned(
+                    top: 10,
+                    right: 10,
+                    child: Container(
+                      height: 140,
+                      width: 140,
+                      decoration: BoxDecoration(
+                        color: mediumGreenColor,
+                        shape: BoxShape.circle,
+                      ),
+                    ),
+                  ),
+                  Positioned(
+                    top: 20,
+                    right: 20,
+                    child: Container(
+                      height: 120,
+                      width: 120,
+                      decoration: BoxDecoration(
+                        color: darkGreenColor,
+                        shape: BoxShape.circle,
+                      ),
+                    ),
+                  ),
+                  Positioned(
+                    top: 40,
+                    right: 40,
+                    child: Icon(
+                      Icons.email,
+                      size: 80,
+                      color: mainColor,
+                    ),
+                  ),
+                ],
+              ),
+              SizedBox(
+                height: 40,
+              ),
+              Text(
+                'メールを確認してください',
+                style: TextStyle(
+                  fontSize: 21,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+              SizedBox(
+                height: 16,
+              ),
+              RichText(
+                text: TextSpan(
+                  style: TextStyle(
+                    fontSize: 18,
+                    height: 1.6,
+                    color: blackColor,
+                  ),
+                  children: [
+                    TextSpan(
+                      text: '${widget.targetEmail}',
+                      style: TextStyle(
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                    TextSpan(
+                      text:
+                          '宛に、パスワード再設定手続きのためのメールを送信いたしました。お手続きを完了していただくことで、新しいパスワードを設定できます。',
+                    ),
+                  ],
+                ),
+              ),
+              SizedBox(
+                height: 40,
+              ),
+              InkWell(
+                onTap: () async {
+                  await resetPasswordForm(context, userProvider);
+                },
+                child: Container(
+                  width: double.infinity,
+                  alignment: Alignment.center,
+                  padding: const EdgeInsets.symmetric(
+                    vertical: 12,
+                  ),
+                  decoration: const ShapeDecoration(
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.all(
+                        Radius.circular(4),
+                      ),
+                    ),
+                    color: heavyBlueColor,
+                  ),
+                  child: userProvider.getLoading
+                      ? const CircularProgressIndicator(
+                          color: mainColor,
+                        )
+                      : const Text(
+                          'メールを再送信',
+                          style: TextStyle(
+                            color: mainColor,
+                            fontWeight: FontWeight.bold,
+                          ),
+                        ),
+                ),
+              ),
+              SizedBox(
+                height: 32,
+              ),
+              InkWell(
+                onTap: navigatorToLogin,
+                child: Container(
+                  width: double.infinity,
+                  alignment: Alignment.center,
+                  padding: const EdgeInsets.symmetric(
+                    vertical: 12,
+                  ),
+                  decoration: const ShapeDecoration(
+                    shape: RoundedRectangleBorder(
+                      side: BorderSide(
+                        color: heavyBlueColor,
+                      ),
+                      borderRadius: BorderRadius.all(
+                        Radius.circular(4),
+                      ),
+                    ),
+                    color: mainColor,
+                  ),
+                  child: userProvider.getLoading
+                      ? const CircularProgressIndicator(
+                          color: heavyBlueColor,
+                        )
+                      : const Text(
+                          'ログイン画面に戻る',
+                          style: TextStyle(
+                            color: heavyBlueColor,
+                            fontWeight: FontWeight.bold,
+                          ),
+                        ),
+                ),
+              ),
+              Flexible(
+                flex: 1,
+                child: Container(),
+              )
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/view/login/login_page.dart
+++ b/lib/view/login/login_page.dart
@@ -75,7 +75,7 @@ class _LoginPageState extends State<LoginPage> {
       UserProvider userProvider,
     ) async {
       userProvider.startLoading();
-      String res = await AuthMethods().signInWithGoogleAccount(context);
+      String res = await AuthMethods().signInWithGoogleAccount();
 
       if (res == successRes) {
         res = successLogin;

--- a/lib/view/login/login_page.dart
+++ b/lib/view/login/login_page.dart
@@ -1,12 +1,14 @@
 import 'package:flutter/material.dart';
 import 'package:muscle_training_app/constant/colors.dart';
 import 'package:muscle_training_app/constant/text_resorce.dart';
+import 'package:muscle_training_app/main.dart';
 import 'package:muscle_training_app/providers/user_provider.dart';
 import 'package:muscle_training_app/util/show_snackbar.dart';
 import 'package:muscle_training_app/resources/auth_methods.dart';
 import 'package:muscle_training_app/resposive/mobile_screen_layout.dart';
 import 'package:muscle_training_app/resposive/resposive_layout.dart';
 import 'package:muscle_training_app/resposive/web_screen_layout.dart';
+import 'package:muscle_training_app/view/login/reset_password_page.dart';
 import 'package:muscle_training_app/view/signup/signup_page.dart';
 import 'package:muscle_training_app/widgets/text_field_input.dart';
 import 'package:provider/provider.dart';
@@ -46,7 +48,7 @@ class _LoginPageState extends State<LoginPage> {
         res = successLogin;
         Navigator.of(context).pushReplacement(
           MaterialPageRoute(
-            builder: (context) => const ResponsiveLayout(
+            builder: (context) => ResponsiveLayout(
               webScreenLayout: WebScreenLayout(),
               mobileScreenLayout: MobileScreenLayout(),
             ),
@@ -73,13 +75,13 @@ class _LoginPageState extends State<LoginPage> {
       UserProvider userProvider,
     ) async {
       userProvider.startLoading();
-      String res = await AuthMethods().signInWithGoogleAccount();
+      String res = await AuthMethods().signInWithGoogleAccount(context);
 
       if (res == successRes) {
         res = successLogin;
-        Navigator.of(context).pushReplacement(
+        await Navigator.of(context).pushReplacement(
           MaterialPageRoute(
-            builder: (context) => const ResponsiveLayout(
+            builder: (context) => ResponsiveLayout(
               webScreenLayout: WebScreenLayout(),
               mobileScreenLayout: MobileScreenLayout(),
             ),
@@ -163,6 +165,24 @@ class _LoginPageState extends State<LoginPage> {
                 flex: 1,
                 child: Container(),
               ),
+              TextButton(
+                style: TextButton.styleFrom(
+                  foregroundColor: heavyBlueColor,
+                ),
+                onPressed: () {
+                  Navigator.of(context).push(
+                    MaterialPageRoute(
+                      builder: (context) => ResetPasswordPage(),
+                    ),
+                  );
+                },
+                child: Align(
+                  alignment: Alignment.centerRight,
+                  child: Text(
+                    forgot_your_password,
+                  ),
+                ),
+              ),
               InkWell(
                 onTap: () async {
                   await loginUser(context, userProvider);
@@ -189,6 +209,7 @@ class _LoginPageState extends State<LoginPage> {
                           'ログイン',
                           style: TextStyle(
                             color: mainColor,
+                            fontWeight: FontWeight.bold,
                           ),
                         ),
                 ),
@@ -232,7 +253,7 @@ class _LoginPageState extends State<LoginPage> {
                         vertical: 8,
                       ),
                       child: const Text(
-                        '新規登録',
+                        '新規登録画面へ',
                         style: TextStyle(
                           fontSize: 20,
                           fontWeight: FontWeight.bold,

--- a/lib/view/login/login_page.dart
+++ b/lib/view/login/login_page.dart
@@ -10,6 +10,7 @@ import 'package:muscle_training_app/resposive/web_screen_layout.dart';
 import 'package:muscle_training_app/view/signup/signup_page.dart';
 import 'package:muscle_training_app/widgets/text_field_input.dart';
 import 'package:provider/provider.dart';
+import 'package:sign_in_button/sign_in_button.dart';
 
 class LoginPage extends StatefulWidget {
   const LoginPage({super.key});
@@ -67,6 +68,31 @@ class _LoginPageState extends State<LoginPage> {
       );
     }
 
+    Future<void> signInWithGoogle(
+      BuildContext context,
+      UserProvider userProvider,
+    ) async {
+      userProvider.startLoading();
+      String res = await AuthMethods().signInWithGoogleAccount();
+
+      if (res == successRes) {
+        res = successLogin;
+        Navigator.of(context).pushReplacement(
+          MaterialPageRoute(
+            builder: (context) => const ResponsiveLayout(
+              webScreenLayout: WebScreenLayout(),
+              mobileScreenLayout: MobileScreenLayout(),
+            ),
+          ),
+        );
+        userProvider.endLoading();
+        showSnackBar(res, context);
+      } else {
+        showSnackBar(res, context);
+      }
+      userProvider.endLoading();
+    }
+
     return Scaffold(
       backgroundColor: secondaryColor,
       body: SafeArea(
@@ -111,6 +137,11 @@ class _LoginPageState extends State<LoginPage> {
               ),
               TextFieldInput(
                 textEditingController: _emailController,
+                prefixIcon: Icon(
+                  Icons.email,
+                  size: 20,
+                  color: blackColor,
+                ),
                 hintText: 'example@email.com',
                 textInputType: TextInputType.emailAddress,
               ),
@@ -119,12 +150,18 @@ class _LoginPageState extends State<LoginPage> {
               ),
               TextFieldInput(
                 textEditingController: _passwordController,
+                prefixIcon: Icon(
+                  Icons.lock,
+                  size: 20,
+                  color: blackColor,
+                ),
                 hintText: 'パスワード',
                 textInputType: TextInputType.text,
                 isPass: true,
               ),
-              const SizedBox(
-                height: 24,
+              Flexible(
+                flex: 1,
+                child: Container(),
               ),
               InkWell(
                 onTap: () async {
@@ -157,10 +194,21 @@ class _LoginPageState extends State<LoginPage> {
                 ),
               ),
               const SizedBox(
-                height: 32,
+                height: 24,
+              ),
+              Container(
+                width: double.infinity,
+                alignment: Alignment.center,
+                child: SignInButton(
+                  text: loginOnGoogle,
+                  Buttons.google,
+                  onPressed: () async {
+                    await signInWithGoogle(context, userProvider);
+                  },
+                ),
               ),
               Flexible(
-                flex: 2,
+                flex: 1,
                 child: Container(),
               ),
               Column(

--- a/lib/view/login/reset_password_page.dart
+++ b/lib/view/login/reset_password_page.dart
@@ -1,0 +1,162 @@
+import 'package:muscle_training_app/constant/colors.dart';
+import 'package:muscle_training_app/constant/text_resorce.dart';
+import 'package:muscle_training_app/providers/user_provider.dart';
+import 'package:muscle_training_app/resources/auth_methods.dart';
+import 'package:muscle_training_app/util/show_snackbar.dart';
+import 'package:muscle_training_app/view/login/email_confirmation_page.dart';
+import 'package:muscle_training_app/widgets/text_field_input.dart';
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+class ResetPasswordPage extends StatefulWidget {
+  @override
+  _ResetPasswordPageState createState() => _ResetPasswordPageState();
+}
+
+class _ResetPasswordPageState extends State<ResetPasswordPage> {
+  @override
+  Widget build(BuildContext context) {
+    final TextEditingController _emailController = TextEditingController();
+    final userProvider = Provider.of<UserProvider>(context);
+
+    @override
+    void dispose() {
+      super.dispose();
+      _emailController.dispose();
+    }
+
+    void navigatorToLogin() {
+      Navigator.of(context).pop();
+    }
+
+    Future<void> resetPasswordForm(
+      BuildContext context,
+      UserProvider userProvider,
+    ) async {
+      userProvider.startLoading();
+      String res = await AuthMethods().resetPasswordForm(
+        targetEmail: _emailController.text,
+      );
+
+      if (res == successRes) {
+        res = successResendEmail;
+        Navigator.of(context).pushReplacement(
+          MaterialPageRoute(
+            builder: (context) => EmailConfirmationPage(
+              targetEmail: _emailController.text,
+            ),
+          ),
+        );
+        userProvider.endLoading();
+        showSnackBar(res, context);
+      } else {
+        showSnackBar(res, context);
+      }
+      userProvider.endLoading();
+    }
+
+    return Scaffold(
+      backgroundColor: secondaryColor,
+      body: SafeArea(
+        child: Container(
+          padding: const EdgeInsets.symmetric(
+            horizontal: 32,
+          ),
+          width: double.infinity,
+          child: Column(
+            children: [
+              Flexible(
+                flex: 1,
+                child: Container(),
+              ),
+              Image.asset(
+                '/Users/nakasatokiichi/StudioProjects/Muscle_training_app/assets/icons/1024.png',
+                height: 104,
+              ),
+              Flexible(
+                flex: 1,
+                child: Container(),
+              ),
+              Text(
+                'パスワード再設定メールを送信',
+                style: TextStyle(
+                  fontSize: 24,
+                ),
+              ),
+              const SizedBox(
+                height: 80,
+              ),
+              TextFieldInput(
+                textEditingController: _emailController,
+                prefixIcon: Icon(
+                  Icons.email,
+                  size: 20,
+                  color: blackColor,
+                ),
+                hintText: 'example@email.com',
+                textInputType: TextInputType.emailAddress,
+              ),
+              SizedBox(
+                height: 32,
+              ),
+              InkWell(
+                onTap: () async {
+                  await resetPasswordForm(context, userProvider);
+                },
+                child: Container(
+                  width: double.infinity,
+                  alignment: Alignment.center,
+                  padding: const EdgeInsets.symmetric(
+                    vertical: 12,
+                  ),
+                  decoration: const ShapeDecoration(
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.all(
+                        Radius.circular(4),
+                      ),
+                    ),
+                    color: heavyBlueColor,
+                  ),
+                  child: userProvider.getLoading
+                      ? const CircularProgressIndicator(
+                          color: mainColor,
+                        )
+                      : const Text(
+                          'メールを送信',
+                          style: TextStyle(
+                            color: mainColor,
+                            fontWeight: FontWeight.bold,
+                          ),
+                        ),
+                ),
+              ),
+              Flexible(
+                flex: 1,
+                child: Container(),
+              ),
+              GestureDetector(
+                onTap: navigatorToLogin,
+                child: Container(
+                  padding: const EdgeInsets.symmetric(
+                    vertical: 8,
+                  ),
+                  child: const Text(
+                    'ログインページに戻る',
+                    style: TextStyle(
+                      fontSize: 18,
+                      fontWeight: FontWeight.bold,
+                      color: linkBlue,
+                    ),
+                  ),
+                ),
+              ),
+              const SizedBox(
+                height: 40,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/view/memo/memo_page.dart
+++ b/lib/view/memo/memo_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:muscle_training_app/constant/colors.dart';
 import 'package:muscle_training_app/models/memo_model/memo_model.dart';
+import 'package:muscle_training_app/view/memo/add_memo.dart';
 import 'package:muscle_training_app/view/memo/table_memo.dart';
 import 'package:provider/provider.dart';
 
@@ -83,6 +84,32 @@ class MemoPage {
             },
           ),
         ),
+        floatingActionButton: Builder(
+          builder: (context) {
+            return buildFloatingActionButton(context);
+          },
+        ),
+      ),
+    );
+  }
+
+  Widget buildFloatingActionButton(BuildContext context) {
+    return FloatingActionButton(
+      heroTag: '1',
+      tooltip: 'メニューを表示する',
+      onPressed: () {
+        Navigator.of(context).push(
+          MaterialPageRoute(
+            builder: (context) => AddMemoPage(),
+          ),
+        );
+      },
+      backgroundColor: addFloationActionButtonColor,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(30),
+      ),
+      child: const Icon(
+        Icons.add,
       ),
     );
   }

--- a/lib/view/menu/add_menu_page.dart
+++ b/lib/view/menu/add_menu_page.dart
@@ -125,13 +125,11 @@ class _AddMenuPageState extends State<AddMenuPage> {
     );
   }
 
-  void buttonPressed1(AddMenuModel model) {
+  void buttonPressed1(AddMenuModel model, BuildContext context) {
     if (_added) {
       return menuList.add(
         AddMenuWidget(
           context,
-          // onCheck(model),
-          // model,
         ),
       );
     } else {}
@@ -217,7 +215,7 @@ class _AddMenuPageState extends State<AddMenuPage> {
         setState(() {
           _added = true;
         });
-        buttonPressed1(model);
+        buttonPressed1(model, context);
       },
       backgroundColor: addFloationActionButtonColor,
       shape: RoundedRectangleBorder(
@@ -225,7 +223,6 @@ class _AddMenuPageState extends State<AddMenuPage> {
       ),
       child: const Icon(
         Icons.add,
-        color: mainColor,
       ),
     );
   }

--- a/lib/view/menu/menu_page.dart
+++ b/lib/view/menu/menu_page.dart
@@ -70,132 +70,124 @@ class MenuPage {
 
   Widget buildBody(
       BuildContext context, dynamic menu, int menuIndex, String uid) {
-    return Slidable(
-      endActionPane: ActionPane(
-        motion: const ScrollMotion(),
-        children: [
-          SlidableAction(
-            onPressed: (BuildContext context) {
-              // 編集画面に遷移
-              Navigator.push(
-                context,
-                MaterialPageRoute(
-                  builder: (context) => EditMenuPage(menu: menu),
+    return Padding(
+      padding: const EdgeInsets.all(6),
+      child: Card(
+        // borderOnForeground: false,
+        shape: Border.symmetric(
+            vertical: BorderSide(
+          width: 7,
+          color: linkBlue,
+        )),
+        elevation: 4,
+        child: ListTile(
+          leading: Icon(Icons.assignment),
+          title: Row(
+            children: [
+              Text(
+                'メニュー${menuIndex + 1}: ',
+                style: const TextStyle(
+                  fontSize: 14,
                 ),
-              );
-            },
-            backgroundColor: blackColor,
-            foregroundColor: mainColor,
-            icon: Icons.edit,
-            label: '編集',
-          ),
-          SlidableAction(
-            onPressed: (context) async {
-              final delete = await showDialog<bool>(
-                context: context,
-                builder: (BuildContext context) => AlertDialog(
-                  title: const Text('削除の確認'),
-                  content: const Text('メニューを削除しますか？'),
-                  actions: [
-                    TextButton(
-                      onPressed: () => Navigator.pop(context, false),
-                      style: TextButton.styleFrom(
-                        foregroundColor: blackColor,
-                      ),
-                      child: const Text('いいえ'),
-                    ),
-                    TextButton(
-                      onPressed: () => Navigator.pop(context, true),
-                      style: TextButton.styleFrom(
-                        foregroundColor: deleteColor,
-                      ),
-                      child: const Text('削除'),
-                    ),
-                  ],
-                ),
-              );
-              if (delete ?? false) {
-                await FirebaseFirestore.instance
-                    .collection('users')
-                    .doc(uid)
-                    .collection('menus')
-                    .doc(menu.id)
-                    .delete();
-
-                // メニュードキュメントに紐づくメモサブコレクションを取得して削除
-                await FirebaseFirestore.instance
-                    .collection('users')
-                    .doc(uid)
-                    .collection('menus')
-                    .doc(menu.id)
-                    .collection('memos')
-                    .get()
-                    .then((querySnapshot) {
-                  querySnapshot.docs.forEach((doc) {
-                    doc.reference.delete();
-                  });
-                });
-              }
-            },
-            backgroundColor: deleteColor,
-            foregroundColor: mainColor,
-            icon: Icons.delete,
-            label: '削除',
-          ),
-        ],
-      ),
-      child: Padding(
-        padding: const EdgeInsets.all(6),
-        child: Card(
-          // borderOnForeground: false,
-          shape: Border.symmetric(
-              vertical: BorderSide(
-            width: 7,
-            color: linkBlue,
-          )),
-          elevation: 4,
-          child: ListTile(
-            leading: const Icon(Icons.assignment),
-            title: Row(
-              children: [
-                Text(
-                  'メニュー${menuIndex + 1}: ',
-                  style: const TextStyle(
-                    fontSize: 14,
-                  ),
-                ),
-                Text(
-                  '${menu['menuName']}',
-                  style: const TextStyle(
-                    fontSize: 16,
-                    fontWeight: FontWeight.bold,
-                  ),
-                ),
-              ],
-            ),
-            subtitle: Text(
-              '最終更新日: ',
-              style: const TextStyle(
-                fontSize: 12,
-                color: blackColor,
               ),
-            ),
-            trailing: Icon(
-              Icons.arrow_back,
-            ),
-            dense: true,
-            tileColor: mainColor,
-            shape: const RoundedRectangleBorder(
-              borderRadius: BorderRadius.all(Radius.circular(10)),
-            ),
-            onTap: () {
-              Navigator.of(context).push(
-                MaterialPageRoute(
-                  builder: (context) => DetailMenuPage(menu: menu),
+              Text(
+                '${menu['menuName']}',
+                style: const TextStyle(
+                  fontSize: 16,
+                  fontWeight: FontWeight.bold,
                 ),
-              );
-            },
+              ),
+            ],
           ),
+          subtitle: Text(
+            '最終更新日: ',
+            style: const TextStyle(
+              fontSize: 12,
+              color: blackColor,
+            ),
+          ),
+          trailing: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              SizedBox(
+                width: 20,
+              ),
+              IconButton(
+                icon: Icon(Icons.edit),
+                onPressed: () {
+                  // 編集画面に遷移
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (context) => EditMenuPage(menu: menu),
+                    ),
+                  );
+                },
+              ),
+              IconButton(
+                icon: Icon(Icons.delete),
+                onPressed: () async {
+                  final delete = await showDialog<bool>(
+                    context: context,
+                    builder: (BuildContext context) => AlertDialog(
+                      title: const Text('削除の確認'),
+                      content: const Text('メニューを削除しますか？'),
+                      actions: [
+                        TextButton(
+                          onPressed: () => Navigator.pop(context, false),
+                          style: TextButton.styleFrom(
+                            foregroundColor: blackColor,
+                          ),
+                          child: const Text('いいえ'),
+                        ),
+                        TextButton(
+                          onPressed: () => Navigator.pop(context, true),
+                          style: TextButton.styleFrom(
+                            foregroundColor: deleteColor,
+                          ),
+                          child: const Text('削除'),
+                        ),
+                      ],
+                    ),
+                  );
+                  if (delete ?? false) {
+                    await FirebaseFirestore.instance
+                        .collection('users')
+                        .doc(uid)
+                        .collection('menus')
+                        .doc(menu.id)
+                        .delete();
+
+                    // メニュードキュメントに紐づくメモサブコレクションを取得して削除
+                    await FirebaseFirestore.instance
+                        .collection('users')
+                        .doc(uid)
+                        .collection('menus')
+                        .doc(menu.id)
+                        .collection('memos')
+                        .get()
+                        .then((querySnapshot) {
+                      querySnapshot.docs.forEach((doc) {
+                        doc.reference.delete();
+                      });
+                    });
+                  }
+                },
+              ),
+            ],
+          ),
+          dense: true,
+          tileColor: mainColor,
+          shape: const RoundedRectangleBorder(
+            borderRadius: BorderRadius.all(Radius.circular(10)),
+          ),
+          onTap: () {
+            Navigator.of(context).push(
+              MaterialPageRoute(
+                builder: (context) => DetailMenuPage(menu: menu),
+              ),
+            );
+          },
         ),
       ),
     );

--- a/lib/view/menu/menu_page.dart
+++ b/lib/view/menu/menu_page.dart
@@ -2,8 +2,10 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_picker/flutter_picker.dart';
 import 'package:flutter_slidable/flutter_slidable.dart';
+import 'package:flutter_speed_dial/flutter_speed_dial.dart';
 import 'package:muscle_training_app/constant/colors.dart';
 import 'package:muscle_training_app/models/menu_model/menu_model.dart';
+import 'package:muscle_training_app/view/menu/add_menu_page.dart';
 import 'package:muscle_training_app/view/menu/add_my_menu_to_memos_page.dart';
 import 'package:muscle_training_app/view/menu/detail_menu_page.dart';
 import 'package:muscle_training_app/view/menu/edit_menu_page.dart';
@@ -203,22 +205,40 @@ class MenuPage {
     return Builder(builder: (context) {
       final MenuModel menuModel =
           Provider.of<MenuModel>(context, listen: false);
-      return FloatingActionButton(
-        heroTag: '1',
-        tooltip: 'マイメニューをメモに追加する',
-        onPressed: () {
-          showWidgetPicker(
-              context, menuModel.getMenuNameList, menuModel.getMenus);
-          print('menuModel.getMenuNameList: ${menuModel.getMenuNameList}');
-        },
+      return SpeedDial(
+        icon: Icons.add,
         backgroundColor: addFloationActionButtonColor,
-        shape: RoundedRectangleBorder(
-          borderRadius: BorderRadius.circular(30),
-        ),
-        child: const Icon(
-          Icons.add,
-          color: mainColor,
-        ),
+        spaceBetweenChildren: 8,
+        children: [
+          SpeedDialChild(
+            child: Icon(Icons.edit_note),
+            label: 'マイメニューをメモ一覧に追加する',
+            backgroundColor: addFloationActionButtonColor,
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(30),
+            ),
+            onTap: () {
+              showWidgetPicker(
+                  context, menuModel.getMenuNameList, menuModel.getMenus);
+              print('menuModel.getMenuNameList: ${menuModel.getMenuNameList}');
+            },
+          ),
+          SpeedDialChild(
+            child: Icon(Icons.assignment_add),
+            label: 'マイメニューを追加する',
+            backgroundColor: addFloationActionButtonColor,
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(30),
+            ),
+            onTap: () {
+              Navigator.of(context).push(
+                MaterialPageRoute(
+                  builder: (context) => AddMenuPage(),
+                ),
+              );
+            },
+          ),
+        ],
       );
     });
   }

--- a/lib/view/profile/account_setting_page.dart
+++ b/lib/view/profile/account_setting_page.dart
@@ -2,7 +2,6 @@ import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:muscle_training_app/constant/colors.dart';
 import 'package:muscle_training_app/view/profile/beginner_tutorial/beginner_tutorial.dart';
-import 'package:muscle_training_app/view/login/login_page.dart';
 import 'package:muscle_training_app/view/profile/notification/notification_permission_page.dart';
 
 class AccountSettingPage extends StatefulWidget {
@@ -69,7 +68,6 @@ class _AccountSettingPageState extends State<AccountSettingPage> {
             () {
               Navigator.of(context).push(
                 MaterialPageRoute(
-                  // builder: (context) => const NotificationSettingPage(),
                   builder: (context) => const NotificationPermissionPage(),
                 ),
               );
@@ -83,18 +81,8 @@ class _AccountSettingPageState extends State<AccountSettingPage> {
             Icons.logout,
             'ログアウト',
             () async {
-              // ログアウト処理
-              // 内部で保持しているログイン情報等が初期化される
-              // （現時点ではログアウト時はこの処理を呼び出せばOKと、思うぐらいで大丈夫）
               await FirebaseAuth.instance.signOut();
-              // ログイン画面に遷移＋チャット画面を破棄
-              await Navigator.of(context).pushReplacement(
-                MaterialPageRoute(
-                  builder: (context) {
-                    return const LoginPage();
-                  },
-                ),
-              );
+              Navigator.of(context).pop();
             },
           ),
         ],

--- a/lib/view/profile/profile_page.dart
+++ b/lib/view/profile/profile_page.dart
@@ -15,6 +15,7 @@ import 'package:muscle_training_app/view/profile/training_frequency_visualizatio
 import 'package:muscle_training_app/view/profile/user_search_page.dart';
 import 'package:muscle_training_app/view/profile/widgets/follow_button.dart';
 import 'package:muscle_training_app/util/show_snackbar.dart';
+import 'package:muscle_training_app/view/profile/widgets/open_dialog.dart';
 
 class ProfilePage extends StatefulWidget {
   final String uid;
@@ -258,14 +259,30 @@ class _ProfileScreenState extends State<ProfilePage> {
                             Stack(
                               children: [
                                 _image != null
-                                    ? CircleAvatar(
-                                        radius: 40,
-                                        backgroundImage: MemoryImage(_image!),
+                                    ? InkWell(
+                                        onTap: () async {
+                                          await imageDialog(
+                                            context,
+                                            userData['photoUrl'],
+                                          );
+                                        },
+                                        child: CircleAvatar(
+                                          radius: 40,
+                                          backgroundImage: MemoryImage(_image!),
+                                        ),
                                       )
-                                    : CircleAvatar(
-                                        radius: 40,
-                                        backgroundImage: NetworkImage(
-                                          userData['photoUrl'],
+                                    : InkWell(
+                                        onTap: () async {
+                                          await imageDialog(
+                                            context,
+                                            userData['photoUrl'],
+                                          );
+                                        },
+                                        child: CircleAvatar(
+                                          radius: 40,
+                                          backgroundImage: AssetImage(
+                                            userData['photoUrl'],
+                                          ),
                                         ),
                                       ),
                                 Positioned(

--- a/lib/view/profile/profile_page.dart
+++ b/lib/view/profile/profile_page.dart
@@ -258,7 +258,8 @@ class _ProfileScreenState extends State<ProfilePage> {
                           children: [
                             Stack(
                               children: [
-                                _image != null
+                                userData['photoUrl'] ==
+                                        'assets/icons/1024 1.png'
                                     ? InkWell(
                                         onTap: () async {
                                           await imageDialog(
@@ -268,7 +269,9 @@ class _ProfileScreenState extends State<ProfilePage> {
                                         },
                                         child: CircleAvatar(
                                           radius: 40,
-                                          backgroundImage: MemoryImage(_image!),
+                                          backgroundImage: AssetImage(
+                                            userData['photoUrl'],
+                                          ),
                                         ),
                                       )
                                     : InkWell(
@@ -280,7 +283,7 @@ class _ProfileScreenState extends State<ProfilePage> {
                                         },
                                         child: CircleAvatar(
                                           radius: 40,
-                                          backgroundImage: AssetImage(
+                                          backgroundImage: NetworkImage(
                                             userData['photoUrl'],
                                           ),
                                         ),

--- a/lib/view/profile/training_frequency_visualization.dart
+++ b/lib/view/profile/training_frequency_visualization.dart
@@ -50,7 +50,7 @@ Widget buildBody(
             crossAxisAlignment: CrossAxisAlignment.center,
             children: [
               Container(
-                height: 200,
+                height: 210,
                 width: 270,
                 child: GridView.builder(
                   gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(

--- a/lib/view/profile/user_search_page.dart
+++ b/lib/view/profile/user_search_page.dart
@@ -22,7 +22,6 @@ class _UserSearchPageState extends State<UserSearchPage> {
 
   @override
   Widget build(BuildContext context) {
-    print('1: $isShowUsers');
     return Scaffold(
       appBar: AppBar(
         backgroundColor: secondaryColor,
@@ -80,26 +79,33 @@ class _UserSearchPageState extends State<UserSearchPage> {
                     vertical: 16,
                     horizontal: 8,
                   ),
-                  itemCount: (snapshot.data! as dynamic).docs.length,
+                  itemCount: snapshot.data!.docs.length,
                   itemBuilder: (context, index) {
                     return InkWell(
                       onTap: () => Navigator.of(context).push(
                         MaterialPageRoute(
                           builder: (context) => ProfilePage(
-                            uid: (snapshot.data! as dynamic).docs[index]['uid'],
+                            uid: snapshot.data!.docs[index]['uid'],
                           ),
                         ),
                       ),
                       child: ListTile(
-                        leading: CircleAvatar(
-                          // backgroundImage: NetworkImage(
-                          backgroundImage: AssetImage(
-                            (snapshot.data! as dynamic).docs[index]['photoUrl'],
-                          ),
-                          radius: 16,
-                        ),
+                        leading: snapshot.data!.docs[index]['photoUrl'] ==
+                                'assets/icons/1024 1.png'
+                            ? CircleAvatar(
+                                backgroundImage: AssetImage(
+                                  snapshot.data!.docs[index]['photoUrl'],
+                                ),
+                                radius: 16,
+                              )
+                            : CircleAvatar(
+                                backgroundImage: NetworkImage(
+                                  snapshot.data!.docs[index]['photoUrl'],
+                                ),
+                                radius: 16,
+                              ),
                         title: Text(
-                          (snapshot.data! as dynamic).docs[index]['username'],
+                          snapshot.data!.docs[index]['username'],
                         ),
                       ),
                     );
@@ -108,22 +114,7 @@ class _UserSearchPageState extends State<UserSearchPage> {
               },
             )
           : Center(
-              child: Column(
-                children: [
-                  Text(
-                    'ユーザーを検索中です',
-                    style: TextStyle(
-                      color: blackColor,
-                    ),
-                  ),
-                  SizedBox(
-                    height: 10,
-                  ),
-                  CircularProgressIndicator(
-                    color: linkBlue,
-                  ),
-                ],
-              ),
+              child: Text('気になるユーザーを検索してみましょう！'),
             ),
     );
   }

--- a/lib/view/profile/widgets/open_dialog.dart
+++ b/lib/view/profile/widgets/open_dialog.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/material.dart';
+
+Future<void> imageDialog(BuildContext context, String imageUrl) {
+  return showDialog(
+    context: context,
+    builder: (BuildContext context) {
+      return AlertDialog(
+        backgroundColor: Colors.transparent,
+        elevation: 0,
+        content: imageUrl == 'assets/icons/1024 1.png'
+            ? Image.asset(
+                imageUrl,
+                fit: BoxFit.cover, //写真が周りに目一杯広がるようにする
+              )
+            : Image.network(
+                imageUrl,
+                fit: BoxFit.cover, //写真が周りに目一杯広がるようにする
+              ),
+      );
+    },
+  );
+}

--- a/lib/view/signup/signup_page.dart
+++ b/lib/view/signup/signup_page.dart
@@ -76,7 +76,7 @@ class _SignUpPageState extends State<SignUpPage> {
       UserProvider userProvider,
     ) async {
       userProvider.startLoading();
-      String res = await AuthMethods().signInWithGoogleAccount(context);
+      String res = await AuthMethods().signInWithGoogleAccount();
 
       if (res == successRes) {
         res = successSignUp;

--- a/lib/view/signup/signup_page.dart
+++ b/lib/view/signup/signup_page.dart
@@ -27,7 +27,6 @@ class _SignUpPageState extends State<SignUpPage> {
     final TextEditingController _confirmPasswordController =
         TextEditingController();
     final userProvider = Provider.of<UserProvider>(context);
-    bool _passwordsMatch = false;
 
     @override
     void dispose() {
@@ -37,9 +36,9 @@ class _SignUpPageState extends State<SignUpPage> {
     }
 
     void navigatorToLogin() {
-      Navigator.of(context).push(
+      Navigator.of(context).pushReplacement(
         MaterialPageRoute(
-          builder: (context) => const LoginPage(),
+          builder: (context) => LoginPage(),
         ),
       );
     }
@@ -77,7 +76,7 @@ class _SignUpPageState extends State<SignUpPage> {
       UserProvider userProvider,
     ) async {
       userProvider.startLoading();
-      String res = await AuthMethods().signInWithGoogleAccount();
+      String res = await AuthMethods().signInWithGoogleAccount(context);
 
       if (res == successRes) {
         res = successSignUp;
@@ -216,6 +215,7 @@ class _SignUpPageState extends State<SignUpPage> {
                           '新規登録',
                           style: TextStyle(
                             color: mainColor,
+                            fontWeight: FontWeight.bold,
                           ),
                         ),
                 ),
@@ -259,7 +259,7 @@ class _SignUpPageState extends State<SignUpPage> {
                         vertical: 8,
                       ),
                       child: const Text(
-                        'ログイン',
+                        'ログイン画面へ',
                         style: TextStyle(
                           fontSize: 20,
                           fontWeight: FontWeight.bold,

--- a/lib/view/signup/signup_page.dart
+++ b/lib/view/signup/signup_page.dart
@@ -10,6 +10,7 @@ import 'package:muscle_training_app/resposive/web_screen_layout.dart';
 import 'package:muscle_training_app/view/login/login_page.dart';
 import 'package:muscle_training_app/widgets/text_field_input.dart';
 import 'package:provider/provider.dart';
+import 'package:sign_in_button/sign_in_button.dart';
 
 class SignUpPage extends StatefulWidget {
   const SignUpPage({super.key});
@@ -23,7 +24,10 @@ class _SignUpPageState extends State<SignUpPage> {
   Widget build(BuildContext context) {
     final TextEditingController _emailController = TextEditingController();
     final TextEditingController _passwordController = TextEditingController();
+    final TextEditingController _confirmPasswordController =
+        TextEditingController();
     final userProvider = Provider.of<UserProvider>(context);
+    bool _passwordsMatch = false;
 
     @override
     void dispose() {
@@ -49,6 +53,31 @@ class _SignUpPageState extends State<SignUpPage> {
         email: _emailController.text,
         password: _passwordController.text,
       );
+
+      if (res == successRes) {
+        res = successSignUp;
+        Navigator.of(context).pushReplacement(
+          MaterialPageRoute(
+            builder: (context) => const ResponsiveLayout(
+              webScreenLayout: WebScreenLayout(),
+              mobileScreenLayout: MobileScreenLayout(),
+            ),
+          ),
+        );
+        userProvider.endLoading();
+        showSnackBar(res, context);
+      } else {
+        showSnackBar(res, context);
+      }
+      userProvider.endLoading();
+    }
+
+    Future<void> signUpWithGoogle(
+      BuildContext context,
+      UserProvider userProvider,
+    ) async {
+      userProvider.startLoading();
+      String res = await AuthMethods().signInWithGoogleAccount();
 
       if (res == successRes) {
         res = successSignUp;
@@ -112,24 +141,56 @@ class _SignUpPageState extends State<SignUpPage> {
               ),
               TextFieldInput(
                 textEditingController: _emailController,
+                prefixIcon: Icon(
+                  Icons.email,
+                  size: 20,
+                  color: blackColor,
+                ),
                 hintText: 'example@email.com',
                 textInputType: TextInputType.emailAddress,
               ),
               const SizedBox(
-                height: 24,
+                height: 12,
               ),
               TextFieldInput(
                 textEditingController: _passwordController,
+                prefixIcon: Icon(
+                  Icons.lock,
+                  size: 20,
+                  color: blackColor,
+                ),
                 hintText: 'パスワード',
-                textInputType: TextInputType.text,
+                textInputType: TextInputType.visiblePassword,
                 isPass: true,
               ),
               const SizedBox(
-                height: 24,
+                height: 12,
+              ),
+              TextFieldInput(
+                textEditingController: _confirmPasswordController,
+                prefixIcon: Icon(
+                  Icons.lock,
+                  size: 20,
+                  color: blackColor,
+                ),
+                hintText: '確認用パスワード',
+                textInputType: TextInputType.text,
+                isPass: true,
+              ),
+              Flexible(
+                flex: 1,
+                child: Container(),
               ),
               InkWell(
                 onTap: () async {
-                  await signUpUser(context, userProvider);
+                  String password = _passwordController.text;
+                  String confirmPassword = _confirmPasswordController.text;
+                  if (password == confirmPassword) {
+                    await signUpUser(context, userProvider);
+                  } else {
+                    String res = wrong_password;
+                    showSnackBar(res, context);
+                  }
                 },
                 child: Container(
                   width: double.infinity,
@@ -160,10 +221,21 @@ class _SignUpPageState extends State<SignUpPage> {
                 ),
               ),
               const SizedBox(
-                height: 32,
+                height: 24,
+              ),
+              Container(
+                width: double.infinity,
+                alignment: Alignment.center,
+                child: SignInButton(
+                  Buttons.google,
+                  text: signInOnGoogle,
+                  onPressed: () async {
+                    await signUpWithGoogle(context, userProvider);
+                  },
+                ),
               ),
               Flexible(
-                flex: 2,
+                flex: 1,
                 child: Container(),
               ),
               Column(

--- a/lib/view/tab_memo/tab_memo_page.dart
+++ b/lib/view/tab_memo/tab_memo_page.dart
@@ -57,22 +57,6 @@ class _MemoTabPageState extends State<TabMemoPage>
             ),
           ],
         ),
-        actions: [
-          IconButton(
-            onPressed: () {
-              Navigator.push(
-                context,
-                MaterialPageRoute(
-                  builder: (context) =>
-                      _tabController.index == 0 ? AddMenuPage() : AddMemoPage(),
-                ),
-              );
-            },
-            icon: Icon(
-              Icons.add,
-            ),
-          ),
-        ],
         foregroundColor: blackColor,
         backgroundColor: blueColor,
       ),

--- a/lib/widgets/text_field_input.dart
+++ b/lib/widgets/text_field_input.dart
@@ -1,16 +1,18 @@
 import 'package:flutter/material.dart';
 
 class TextFieldInput extends StatelessWidget {
-  const TextFieldInput ({
+  const TextFieldInput({
     super.key,
     required this.textEditingController,
     this.isPass = false,
+    this.prefixIcon,
     required this.hintText,
     required this.textInputType,
   });
 
   final TextEditingController textEditingController;
   final bool isPass;
+  final Icon? prefixIcon;
   final String hintText;
   final TextInputType textInputType;
 
@@ -23,6 +25,7 @@ class TextFieldInput extends StatelessWidget {
     return TextField(
       controller: textEditingController,
       decoration: InputDecoration(
+        prefixIcon: prefixIcon,
         hintText: hintText,
         border: inputBorder,
         focusedBorder: inputBorder,
@@ -45,7 +48,6 @@ class MemoTextField extends StatelessWidget {
     this.initialValue = '',
     this.onChanged,
     this.isEnabled,
-    
   });
   final String labelText;
   final TextInputType textInputType;

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -14,6 +14,7 @@ import firebase_messaging
 import firebase_storage
 import flutter_local_notifications
 import flutter_localization
+import google_sign_in_ios
 import path_provider_foundation
 import shared_preferences_foundation
 
@@ -27,6 +28,7 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FLTFirebaseStoragePlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseStoragePlugin"))
   FlutterLocalNotificationsPlugin.register(with: registry.registrar(forPlugin: "FlutterLocalNotificationsPlugin"))
   FlutterLocalizationPlugin.register(with: registry.registrar(forPlugin: "FlutterLocalizationPlugin"))
+  FLTGoogleSignInPlugin.register(with: registry.registrar(forPlugin: "FLTGoogleSignInPlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -165,10 +165,10 @@ packages:
     dependency: "direct dev"
     description:
       name: build_runner
-      sha256: "67d591d602906ef9201caf93452495ad1812bea2074f04e25dbd7c133785821b"
+      sha256: "3ac61a79bfb6f6cc11f693591063a7f19a7af628dc52f141743edac5c16e8c22"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.7"
+    version: "2.4.9"
   build_runner_core:
     dependency: transitive
     description:
@@ -623,10 +623,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_riverpod
-      sha256: "4bce556b7ecbfea26109638d5237684538d4abc509d253e6c5c4c5733b360098"
+      sha256: "0f1974eff5bbe774bf1d870e406fc6f29e3d6f1c46bd9c58e7172ff68a785d7d"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.10"
+    version: "2.5.1"
   flutter_slidable:
     dependency: "direct main"
     description:
@@ -761,10 +761,10 @@ packages:
     dependency: "direct main"
     description:
       name: hooks_riverpod
-      sha256: "758b07eba336e3cbacbd81dba481f2228a14102083fdde07045e8514e8054c49"
+      sha256: "45b2030a18bcd6dbd680c2c91bc3b33e3fe7c323e3acb5ecec93a613e2fbaa8a"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.10"
+    version: "2.5.1"
   html:
     dependency: transitive
     description:
@@ -1137,10 +1137,10 @@ packages:
     dependency: transitive
     description:
       name: riverpod
-      sha256: "548e2192eb7aeb826eb89387f814edb76594f3363e2c0bb99dd733d795ba3589"
+      sha256: f21b32ffd26a36555e501b04f4a5dca43ed59e16343f1a30c13632b2351dfa4d
       url: "https://pub.dev"
     source: hosted
-    version: "2.5.0"
+    version: "2.5.1"
   riverpod_analyzer_utils:
     dependency: transitive
     description:
@@ -1153,18 +1153,18 @@ packages:
     dependency: "direct main"
     description:
       name: riverpod_annotation
-      sha256: "77e5d51afa4fa3e67903fb8746f33d368728d7051a0b6c292bcee60aeba46d95"
+      sha256: e5e796c0eba4030c704e9dae1b834a6541814963292839dcf9638d53eba84f5c
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.4"
+    version: "2.3.5"
   riverpod_generator:
     dependency: "direct dev"
     description:
       name: riverpod_generator
-      sha256: "359068f04879347ae4edbe66c81cc95f83fa1743806d1a0c86e55dd3c33ebb32"
+      sha256: d451608bf17a372025fc36058863737636625dfdb7e3cbf6142e0dfeb366ab22
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.11"
+    version: "2.4.0"
   rxdart:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -635,6 +635,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.1"
+  flutter_speed_dial:
+    dependency: "direct main"
+    description:
+      name: flutter_speed_dial
+      sha256: "698a037274a66dbae8697c265440e6acb6ab6cae9ac5f95c749e7944d8f28d41"
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.0"
   flutter_svg:
     dependency: "direct main"
     description:
@@ -653,6 +661,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  font_awesome_flutter:
+    dependency: transitive
+    description:
+      name: font_awesome_flutter
+      sha256: "275ff26905134bcb59417cf60ad979136f1f8257f2f449914b2c3e05bbb4cd6f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "10.7.0"
   freezed:
     dependency: "direct main"
     description:
@@ -685,6 +701,54 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.2"
+  google_identity_services_web:
+    dependency: transitive
+    description:
+      name: google_identity_services_web
+      sha256: "0c56c2c5d60d6dfaf9725f5ad4699f04749fb196ee5a70487a46ef184837ccf6"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.0+2"
+  google_sign_in:
+    dependency: "direct main"
+    description:
+      name: google_sign_in
+      sha256: "0b8787cb9c1a68ad398e8010e8c8766bfa33556d2ab97c439fb4137756d7308f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.2.1"
+  google_sign_in_android:
+    dependency: transitive
+    description:
+      name: google_sign_in_android
+      sha256: "7647893c65e6720973f0e579051c8f84b877b486614d9f70a404259c41a4632e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.1.23"
+  google_sign_in_ios:
+    dependency: transitive
+    description:
+      name: google_sign_in_ios
+      sha256: a058c9880be456f21e2e8571c1126eaacd570bdc5b6c6d9d15aea4bdf22ca9fe
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.7.6"
+  google_sign_in_platform_interface:
+    dependency: transitive
+    description:
+      name: google_sign_in_platform_interface
+      sha256: "1f6e5787d7a120cc0359ddf315c92309069171306242e181c09472d1b00a2971"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.5"
+  google_sign_in_web:
+    dependency: transitive
+    description:
+      name: google_sign_in_web
+      sha256: a278ea2d01013faf341cbb093da880d0f2a552bbd1cb6ee90b5bebac9ba69d77
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.12.3+2"
   graphs:
     dependency: transitive
     description:
@@ -1181,6 +1245,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.4"
+  sign_in_button:
+    dependency: "direct main"
+    description:
+      name: sign_in_button
+      sha256: "977b9b0415d2f3909e642275dfabba7919ba8e111324641b76cae6d1acbd183e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.0"
   simple_gesture_detector:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -69,10 +69,10 @@ dependencies:
 
 dev_dependencies:
   build_runner: ^2.4.7
+  riverpod_generator: ^2.3.11
   flutter_lints: ^2.0.0
   flutter_test:
     sdk: flutter
-  riverpod_generator: ^2.3.11
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec
 # The following section is specific to Flutter packages.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -49,9 +49,11 @@ dependencies:
   flutter_picker: ^2.1.0
   flutter_riverpod: ^2.4.6
   flutter_slidable: ^3.0.1
+  flutter_speed_dial: ^7.0.0
   flutter_svg: ^2.0.9
   freezed: ^2.4.5
   freezed_annotation: ^2.4.1
+  google_sign_in: ^6.2.1
   hooks_riverpod: ^2.4.10
   image_picker: ^0.8.7
   intl: ^0.18.1
@@ -60,6 +62,7 @@ dependencies:
   modal_bottom_sheet: ^3.0.0-pre
   provider: ^6.1.1
   riverpod_annotation: ^2.3.4
+  sign_in_button: ^3.2.0
   table_calendar: ^3.0.9
   timezone: ^0.9.2
   uuid: ^4.3.3

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -8,12 +8,12 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import 'package:muscle_training_app/myapp.dart';
+import 'package:muscle_training_app/main_navigation.dart';
 
 void main() {
   testWidgets('Counter increments smoke test', (WidgetTester tester) async {
     // Build our app and trigger a frame.
-    await tester.pumpWidget(const Myapp());
+    await tester.pumpWidget(const MainNavigation());
 
     // Verify that our counter starts at 0.
     expect(find.text('0'), findsOneWidget);


### PR DESCRIPTION
### チケットリンク

- #29 

### このプルリクでやったこと

- Googleアカウントでサインアップ・サインインできるように設定・処理を追加

- Googleサインアップ・サインインのボタンを設置したので、それに伴いレイアウトの修正をした

- サインアップ画面に確認用のパスワードを入力する欄を設けた

-  ユーザーがパスワードを忘れたときに、パスワードを変更できるページを作成

- 上記のページでメールアドレスを入力すると、

  - 入力されたメールアドレスにパスワード変更できるメールを送信
  
  - メールが届いているか確認させるページに遷移
  
- ユーザー情報をStreamBuilderで監視していたが、別ファイルでriverpodを使って監視する仕様に変更するためのファイルを追加

  - まだ、うまくいっていないので、StreamBuilderのコードはコメントアウト中
  
  - 現状は、ユーザーがログアウトすると画面が変化せず、uidが必要になるページでエラーになる
    (リロードすると直る)

(他の追加機能)

- floatingActionButtonのforegroundの色を白色に変更

- タブメモページのappBarにつけていた機能をfloatingActionButtonを追加し、そこに移した

- プロフィール画面のユーザーアイコンをタップすると、ユーザーアイコンの画像がダイアログでポップアップされるようにした